### PR TITLE
Center the cards, fixes #23

### DIFF
--- a/flip-cards-ui/src/components/FlipCardsGallery.module.css
+++ b/flip-cards-ui/src/components/FlipCardsGallery.module.css
@@ -11,4 +11,5 @@
   justify-content: flex-start;
   flex-wrap: wrap;
   overflow: auto;
+  justify-content: center;
 }


### PR DESCRIPTION
Previously, cards are left-aligned:

![image](https://user-images.githubusercontent.com/6725396/97081807-74970a00-1637-11eb-92b3-1c4423e1c28f.png)

This PR fixes the alignment (issue #23). Cards are now centered on the page:

![image](https://user-images.githubusercontent.com/6725396/97081793-59c49580-1637-11eb-8334-c0c2e0b5e992.png)